### PR TITLE
chore(token-header): add token header

### DIFF
--- a/src/services/requestHandler.js
+++ b/src/services/requestHandler.js
@@ -10,8 +10,14 @@ const axiosInstance = () => {
   if (process.env.NODE_ENV === 'development') {
     apiUrl = 'http://localhost:3000/api';
   }
+
+  let token = '';
+  if (localStorage.getItem('token')) {
+    token = localStorage.getItem('token');
+  }
   const headers = new Headers();
   headers.append('Content-Type', 'application/json');
+  headers.append('Authorization', token);
   const instanceCreate = axios.create({
     baseURL: apiUrl,
     headers,


### PR DESCRIPTION
#### What does this PR do?
- Add `Authorization` token to axios instance

#### Description of Task to be completed?
- Check localStorage for token key
- if a token is present set is in `Authorization` header.
- Assign token header to axios instance for making API request

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
- This feature requires that the team member working on the login and signup features should set the token in localStorage with the key 'token'. That way when the axios instance is called the token will be available to the request header object.

#### What are the relevant pivotal tracker stories?
#160552899

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A