### PR TITLE
#160056388: article view page should contain time it takes to read the article

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10553,6 +10553,11 @@
         }
       }
     },
+    "reading-time": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.1.3.tgz",
+      "integrity": "sha512-SYy+cuoGy1MTLjIbgwTZ+DkDiDq/dE1OnqBQFYytXgNWRZROuqtBdu7HoJ+HbGMnoAinOHnHnqbEUYnpSho5aA=="
+    },
     "realpath-native": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-redux": "^5.0.7",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
+    "reading-time": "^1.1.3",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.5",
     "redux-logger": "^3.0.6",

--- a/public/styles/_articleView.scss
+++ b/public/styles/_articleView.scss
@@ -15,4 +15,8 @@
     .articleView{
         border: 0;
     }
+
+    .article-info-stats p {
+        margin-top: 3px;
+    }
 }

--- a/src/components/ArticleView.jsx
+++ b/src/components/ArticleView.jsx
@@ -4,10 +4,12 @@ import propTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Parser as HtmlToReactParser } from 'html-to-react';
 import { Redirect } from 'react-router';
+import readingTime from 'reading-time';
 import loadAricleAction from '../actions/loadArticleAction';
 import TagView from './TagView';
 import deleteArticleAction from '../actions/deleteArticle';
 import Like from './Like';
+
 
 const htmlToReactParser = new HtmlToReactParser();
 /**
@@ -89,6 +91,7 @@ export class ArticleView extends Component {
     }
     const ReactElement = htmlToReactParser
       .parse(unescape(article.body));
+    const stats = readingTime(unescape(article.body));
     return (
       <div id="article-page">
         <Container id="articleView">
@@ -97,12 +100,20 @@ export class ArticleView extends Component {
 
             <h1 className="header">{article.title}</h1>
             <Header.Subheader className="sub-header">
-            Created By: @
-              {article.author ? article.author.username : ''}
-              {'  '}
+              <div className="article-info-stats">
+                <p>
+               Created By: @
+                  {article.author ? article.author.username : ''}
+                  {'  '}
             on
-              {'  '}
-              {new Date(article.createdAt).toUTCString()}
+                  {'  '}
+                  {new Date(article.createdAt).toUTCString()}
+                </p>
+
+
+                <p>{stats.text}</p>
+              </div>
+
             </Header.Subheader>
           </Header>
 


### PR DESCRIPTION
#### What does this PR do?
- installs `reading-time`
- adds time estimate to the view page

#### Description of Task to be completed?
- users should be able to view the amount of time it takes to read an article

#### How should this be manually tested?
- run `git pull` command from your console
- run `npm install` to get the dependencies
- run `npm run dev` to open the app in the browser
- manually route to `/articles/{slug}` using a valid slug
- time estimate of the article would appear on your screen

#### Any background context you want to provide?
- None

#### What are the relevant pivotal tracker stories?
- 160056377

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-09-27 at 8 35 49 pm" src="https://user-images.githubusercontent.com/38565349/46170171-fc618d00-c294-11e8-8f48-1c4f1e7f03e6.png">
<img width="1440" alt="screen shot 2018-09-27 at 8 35 45 pm" src="https://user-images.githubusercontent.com/38565349/46170174-fc618d00-c294-11e8-8809-2f11fb90d316.png">



#### Questions:
- None